### PR TITLE
Fix broken link to todo-app example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ A collection of Feature-Sliced Examples that show how you can build applications
 
 ## Community examples — full projects
 
-You can see community contributed examples [in the showcase on the official site](https://feature-sliced.design/examples).
+You can see community contributed examples [in the showcase on the official site](https://feature-sliced.github.io/documentation/examples).


### PR DESCRIPTION
## Description
- This PR fixes a broken documentation link to improve navigation for other users.
- Fixed broken link to examples in the main README.md file.

## Changes Made
- Updated the incorrect link to point to the correct path

## Type of Change
- [x] Documentation update